### PR TITLE
Add missing install.iss check

### DIFF
--- a/windows.cmd
+++ b/windows.cmd
@@ -184,6 +184,7 @@ goto exit
     set X_ZIP_NAME=
     cd %X_SOURCE_PATH%
     IF [%INNOSETUP_PATH%] == [] goto make_release_end
+    if not exist "%INNOSETUP_PATH%\install.iss" goto make_release_end
     %INNOSETUP_PATH% install.iss
     if exist "%X_SOURCE_PATH%\release\%X_BUILD_NAME%_%X_BUILD_PREFIX%_install_%X_RELEASE_VERSION%.exe" del "%X_SOURCE_PATH%\release\%X_BUILD_NAME%_%X_BUILD_PREFIX%_install_%X_RELEASE_VERSION%.exe"
     ren "%X_SOURCE_PATH%\release\install.exe" "%X_BUILD_NAME%_%X_BUILD_PREFIX%_install_%X_RELEASE_VERSION%.exe"


### PR DESCRIPTION
When I checked the build logs I found this check was missing to avoid running inno setup