### PR TITLE
Set `X_ARCHITECTURE` with `dpkg --print-architecture`

### DIFF
--- a/linux.sh
+++ b/linux.sh
@@ -10,22 +10,9 @@ function check_file
 
 function make_init
 {
-    X_UNAME=$(uname -m)
     export X_REVISION=$(date "+%Y%m%d")
 
-    # TODO more (arm8)
-    X_ARCHITECTURE=$X_UNAME
-    if [[ $X_UNAME == *"x86_64"* ]]; then
-        X_ARCHITECTURE="amd64"
-    fi
-    
-    if [[ $X_UNAME == *"armv7l"* ]]; then
-        X_ARCHITECTURE="armhf"
-    fi
-    
-    if [[ $X_UNAME == *"aarch64"* ]]; then
-        X_ARCHITECTURE="arm64"
-    fi
+    X_ARCHITECTURE=$(dpkg --print-architecture)
     
     export X_ARCHITECTURE
     


### PR DESCRIPTION
This way we can detect all kinds of architectures at once and in one line.