### PR TITLE
Fix wrong `block-size`

### DIFF
--- a/linux.sh
+++ b/linux.sh
@@ -103,7 +103,7 @@ function create_deb_control
         if [ -n "$X_MAINTAINER" ]; then
             echo "Maintainer: $X_MAINTAINER"
         fi
-        echo "Installed-Size: $(du -sb --exclude $X_SOURCE_PATH/release/$X_BUILD_NAME/DEBIAN $X_SOURCE_PATH/release/$X_BUILD_NAME | cut -f 1)"
+        echo "Installed-Size: $(du -sk --exclude $X_SOURCE_PATH/release/$X_BUILD_NAME/DEBIAN $X_SOURCE_PATH/release/$X_BUILD_NAME | cut -f 1)"
         if [ -n "$X_DEPENDS" ]; then
             echo "Depends: $X_DEPENDS"
         fi


### PR DESCRIPTION
Today I found that I used the wrong `block-size` with `du` command in commit 47a227f6723a70cb93125e06e07352b59062ec14, it should be `1024` bytes, not `1` byte, here's the doc: https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-installed-size
I'm sorry about that, and here's the fixing PR.